### PR TITLE
Add missing DiffCommand fromEmptySchema parameter

### DIFF
--- a/src/Command/Doctrine/DiffCommand.php
+++ b/src/Command/Doctrine/DiffCommand.php
@@ -61,6 +61,12 @@ EOT
                 InputOption::VALUE_NONE,
                 'Do not throw an exception when no changes are detected.'
             )
+            ->addOption(
+                'from-empty-schema',
+                null,
+                InputOption::VALUE_NONE,
+                'Generate a full migration as if the current database was empty.'
+            )
             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'Name of the Entity Manager to handle.')
         ;
     }
@@ -72,6 +78,7 @@ EOT
             '--line-length' => $input->getOption('line-length'),
             '--check-database-platform' => $input->getOption('check-database-platform'),
             '--allow-empty-diff' => $input->getOption('allow-empty-diff'),
+            '--from-empty-schema' => $input->getOption('from-empty-schema'),
         ];
 
         if ('' !== (string) $input->getOption('namespace')) {


### PR DESCRIPTION
Hi there!

I recently found out about this bundle and was trying it for my usecase with multiple databases.

However, trying to create migrations for an existing database, I've understood that the `from-empty-schema` was not being correctly passed to Doctrine, leading to:

```                    
  The "--from-empty-schema" option does not exist.  
                                                    

doctrine:migrations:diff [--namespace NAMESPACE] [--filter-expression FILTER-EXPRESSION] [--formatted] [--line-length LINE-LENGTH] [--check-database-platform [CHECK-DATABASE-PLATFORM]] [--allow-empty-diff] [--em EM]
```

This PR should re-add that support back.