### PR TITLE
ListCommand: show all available migrations

### DIFF
--- a/src/Command/Doctrine/ListCommand.php
+++ b/src/Command/Doctrine/ListCommand.php
@@ -34,7 +34,7 @@ EOT
         $newInput->setInteractive($input->isInteractive());
 
         foreach ($this->getDependencyFactories(strval($input->getOption('em'))) as $dependencyFactory) {
-            $otherCommand = new \Doctrine\Migrations\Tools\Console\Command\CurrentCommand($dependencyFactory);
+            $otherCommand = new \Doctrine\Migrations\Tools\Console\Command\ListCommand($dependencyFactory);
             $otherCommand->run($newInput, $output);
         }
 


### PR DESCRIPTION
Fixes: #23

The command "doctrine:migrations:list" doesn't show all available migrations.